### PR TITLE
Fix OSX gnu-getopt intallation instructions

### DIFF
--- a/dcw
+++ b/dcw
@@ -9,7 +9,7 @@ cat <<EOF
 You need to install gnu-getopt to run this program.
 
 If you run this programm on OSX, try:
-    $ brew install gnu-getopt && brew link gnu-getopt
+    $ brew install gnu-getopt && brew link gnu-getopt --force
 
 EOF
     exit 100;


### PR DESCRIPTION
The current instrustion install gnu-getopt but do not put in the path.

```
brew install gnu-getopt && brew link gnu-getopt                                                                                                            17:27:56
==> Downloading https://homebrew.bintray.com/bottles/gnu-getopt-1.1.6.el_capitan.bottle.tar.gz
######################################################################## 100.0%
==> Pouring gnu-getopt-1.1.6.el_capitan.bottle.tar.gz
==> Caveats
This formula is keg-only, which means it was not symlinked into /usr/local.

OS X already provides this software and installing another version in
parallel can cause all kinds of trouble.
==> Summary
🍺  /usr/local/Cellar/gnu-getopt/1.1.6: 33 files, 103.3K
Warning: gnu-getopt is keg-only and must be linked with --force
Note that doing so can interfere with building software.
```